### PR TITLE
chore: Move repository into the correct Snyk organisation

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -10,7 +10,7 @@ jobs:
   security:
     uses: guardian/.github/.github/workflows/sbt-node-snyk.yml@main
     with:
-      ORG: guardian-devtools
+      ORG: guardian-security
       SKIP_SBT: true
       SKIP_NODE: true
       SKIP_GO: false


### PR DESCRIPTION
This repository is owned by @guardian/devx-security. Reflect that in the Snyk organisation placement.